### PR TITLE
Find helper tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+kak-calc-scrollbar

--- a/README.md
+++ b/README.md
@@ -21,13 +21,11 @@ It's the simplest C program ever and should be compilable on almost every system
 gcc kak-calc-scrollbar.c -o kak-calc-scrollbar
 ```
 
-Then, put the new file in a location in your PATH—`~/.local/bin` is recommended, on Linux.
-
-Or you could just have `plug` do it for you—add the following to your kakrc (again, please pay attention to where you output the file):
+Or you could just have `plug` do it for you—add the following to your kakrc:
 
 ```
 plug "kak-lsp/scrollbar.kak" do %{
-    gcc kak-calc-scrollbar.c -o ~/.local/bin/kak-calc-scrollbar
+    gcc kak-calc-scrollbar.c -o kak-calc-scrollbar
 }
 ```
 

--- a/scrollbar.kak
+++ b/scrollbar.kak
@@ -60,7 +60,7 @@ define-command calculate-scrollbar-flags -hidden -override %{
                 "$kak_opt_scrollbar_sel_char" \
                 "$kak_buf_line_count" \
                 "$kak_window_height"
-        echo "set-option buffer scrollbar_flags $kak_timestamp " $(kak-calc-scrollbar "$@")
+        echo "set-option buffer scrollbar_flags $kak_timestamp " $("$kak_opt_scrollbar_plugin_path"/kak-calc-scrollbar "$@")
     }
 }   
 

--- a/scrollbar.kak
+++ b/scrollbar.kak
@@ -1,6 +1,13 @@
 ###############################################################################
 #                               Scrollbar.kak                                 #
 ###############################################################################
+declare-option -hidden str scrollbar_plugin_path %sh{ dirname "$kak_source" }
+
+evaluate-commands %sh{
+    if [ ! -x "$kak_opt_scrollbar_plugin_path"/kak-calc-scrollbar ]; then
+        echo fail kak-calc-scrollbar helper not compiled, scrollbar plugin disabled
+    fi
+}
 
 # V0.0.1 makes no attempt to be computationally efficient!
 # So, the scrollbar loop will be running all the time.


### PR DESCRIPTION
Teach the scrollbar plugin to automatically find the helper tool, and complain when it's not present, instead of requiring the user to manually move it into `$PATH`.