### PR TITLE
Enable scrollbar with commands, not an option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,11 @@ If you'd prefer to use another compilation system, `clang` for instance—which 
 
 ## Using the scrollbar
 
-Once you have scrollbar.kak and calc-scrollbar-kak installed, there is not much to do. Turn on the `enable-scrollbar` option to make it appear. You can set it for all windows in your `kakrc` like so:
+Once you have scrollbar.kak and calc-scrollbar-kak installed, there is not much to do. Use the `scrollbar-enable` command to make it appear in the current window. You can set it for all windows in your `kakrc` like so:
 
-`set-option global enable-scrollbar true`
+```
+hook global WinCreate .* %{ scrollbar-enable }
+```
 
 ## Features & limitations
 

--- a/scrollbar.kak
+++ b/scrollbar.kak
@@ -2,11 +2,6 @@
 #                               Scrollbar.kak                                 #
 ###############################################################################
 
-# Turn on the main scrollbar-drawing hook(s)
-define-command turn-on-scrollbar-hooks -hidden -override %{
-    hook -group scrollbar-kak window RawKey .* update-scrollbar
-}
-
 # The line-specs option for our scrollbar
 declare-option -hidden line-specs scrollbar_flags
 
@@ -39,40 +34,37 @@ define-command update-scrollbar -hidden -override %{
     }
 }   
 
-# Launch / update the scrollbar highlighter
-define-command draw-scrollbar -hidden -override %{
-    addhl -override window/scrollbar-kak flag-lines Scrollbar scrollbar_flags
-}
-
-# Remove the scrollbar for this window
-define-command remove-scrollbar -hidden -override %{
-    rmhl window/scrollbar-kak
-    rmhooks window scrollbar-kak
-}
-
 # Move scrollbar to the left when necessary, as a user-activated command.
 define-command move-scrollbar-to-left -override -docstring %{
     Move the scrollbar to the leftmost position in the stack of highlighters.
     } %{
     rmhl window/scrollbar-kak
-    redraw-scrollbar
+    addhl -override window/scrollbar-kak flag-lines Scrollbar scrollbar_flags
 }
 
 ###############################################################################
-#                              Option Handling                                #
+#                              Setup Commands                                 #
 ###############################################################################
 
-# Option to turn scrollbar on and off
-declare-option bool enable_scrollbar false
+define-command scrollbar-enable -docstring %{
+    Enable the scrollbar in the current window
+} %{
+    # Get notified when scrollbar data needs to be updated
+    hook -group scrollbar-kak window RawKey .* update-scrollbar
 
-# Apply hooks when option is turned on
-hook global WinSetOption enable_scrollbar=true %{
-    turn-on-scrollbar-hooks
+    # Update it right now
     update-scrollbar
-    draw-scrollbar
+
+    # Install the scrollbar highlighter
+    addhl -override window/scrollbar-kak flag-lines Scrollbar scrollbar_flags
 }
 
-# Remove hooks when option is turned off
-hook global WinSetOption enable_scrollbar=false %{
-    remove-scrollbar
+define-command scrollbar-disable -docstring %{
+    Disable the scrollbar in the current window
+} %{
+    # Uninstall the scrollbar highlighter
+    rmhl window/scrollbar-kak
+
+    # Don't get notified when the scrollbar needs to be updated
+    rmhooks window scrollbar-kak
 }


### PR DESCRIPTION
An option is a nice UI because it feels more "built in", but it introduces a load-order dependency - only plugins loaded *after* the scrollbar plugin can set the scrollbar option.

Using commands to enable and disable the scrollbar means they can be called from hooks, which won't be invoked until after all plugins are loaded, solving the load-order dependency. In addition, this makes things a little easier to debug when things go wrong - if the user puts a hook in their `kakrc`, they know they have to debug hooks; if they set an option in their `kakrc` they may spend time debugging options when options aren't the problem. For precedent, see the `autowrap-enable` and `ctags-enable-*` commands in the standard library.

Also, I took the liberty of inlining some helper functions. The "enable" and "disable" logic can now be viewed side-by-side to verify that everything that gets installed also gets cleaned up. Added comments mean it's still possible to understand what the code does without being a Kakoune expert.
