### PR TITLE
Update the scrollbar when the "view-scrolled" user hook is triggered.

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,12 @@ Scrollbar.kak will try to store the compiled tool in the its own plugin folder, 
 
 If you've set up the scrollbar and played about with adding new highlighters, you might want to push it back to its left-most position on the highlighter stack. To do so, use the `move-scrollbar-to-left` command.
 
+## Integrating with Other Plugins
+
+Most of the time, when the view changes it's because the user pressed a key, so we use Kakoune's `RawKey` hook to trigger redrawing the scrollbar. However, there are ways for the view to move without a keypress, like using `execute-keys` or the `:select` command. If you are the author of a plugin that uses such a technique, and you want the scrollbar to update automatically afterward without having to press a key, you can trigger the `view-scrolled` user hook:
+
+    trigger-user-hook view-scrolled
+
 ## License
 
 Oi! 'Ave you got a license for that scrollbar?

--- a/scrollbar.kak
+++ b/scrollbar.kak
@@ -52,6 +52,9 @@ define-command scrollbar-enable -docstring %{
     # Get notified when scrollbar data needs to be updated
     hook -group scrollbar-kak window RawKey .* update-scrollbar
 
+    # Let other plugins notify us if they change the view without a keypress
+    hook -group scrollbar-kak window User view-scrolled update-scrollbar
+
     # Update it right now
     update-scrollbar
 


### PR DESCRIPTION
This lets other plugins integrate a little more smoothly with this one, but doesn't require any hard dependency between them.