### PR TITLE
Update scrollbar on ClientCreate and WinResize

### DIFF
--- a/scrollbar.kak
+++ b/scrollbar.kak
@@ -55,8 +55,8 @@ define-command scrollbar-enable -docstring %{
     # Let other plugins notify us if they change the view without a keypress
     hook -group scrollbar-kak window User ScrollEnd update-scrollbar
 
-    # Update it right now
-    update-scrollbar
+    # Update when a client connects to the window
+    hook -group scrollbar-kak window ClientCreate .* update-scrollbar
 
     # Install the scrollbar highlighter
     addhl -override window/scrollbar-kak flag-lines Scrollbar scrollbar_flags

--- a/scrollbar.kak
+++ b/scrollbar.kak
@@ -51,6 +51,7 @@ define-command scrollbar-enable -docstring %{
 } %{
     # Get notified when scrollbar data needs to be updated
     hook -group scrollbar-kak window RawKey .* update-scrollbar
+    hook -group scrollbar-kak window WinResize .* update-scrollbar
 
     # Let other plugins notify us if they change the view without a keypress
     hook -group scrollbar-kak window User ScrollEnd update-scrollbar


### PR DESCRIPTION
`ClientCreate`: The scrollbar wouldn't show on a new window until pressing a key (triggering `RawKey`) with only `WinCreate`. Updating on the window's `ClientCreate` instead of updating the scrollbar immediately in `scrollbar-enable` fixes this issue. Basically the window waits for a terminal to connect to it before updating it.

`WinResize` should be self-explanatory ;P

Thank you for making scrollbar.kak!